### PR TITLE
Update Pencil2D to v0.6.6

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,14 +1,14 @@
 pkgname=pencil2d
-pkgver=0.6.5.0
+pkgver=0.6.6.0
 pkgrel=1
-_commit=50a0c7c318f38988af85d34e955a5a78d3953474
+_commit=3b3229e2d95e78aff9fac09cc4d9b0d94e1a7535
 pkgdesc="Create traditional hand-drawn animation using both bitmap and vector graphics"
 arch=('x86_64')
 url="https://www.pencil2d.org/"
 license=('GPL')
 depends=('ffmpeg' 'qt5-svg' 'qt5-multimedia' 'qt5-tools')
 source=("${pkgname}.zip::https://github.com/pencil2d/pencil/archive/${_commit}.zip")
-md5sums=('6cadf1803114cdf04dbf53d8b459ee9e')
+md5sums=('8520dc2404556f9c6944df224728a98a')
 
 prepare() {
     cd "${srcdir}/pencil-${_commit}"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,23 +1,21 @@
 pkgname=pencil2d
-pkgver=0.5.3.80
+pkgver=0.6.5.0
 pkgrel=1
-_commit=219fe8402ff004eea31a39f74bfaf3d7166f0cb9
-pkgdesc="Animation software for both bitmap and vector graphics"
+_commit=50a0c7c318f38988af85d34e955a5a78d3953474
+pkgdesc="Create traditional hand-drawn animation using both bitmap and vector graphics"
 arch=('x86_64')
-url="http://www.pencil2d.org/"
+url="https://www.pencil2d.org/"
 license=('GPL')
-depends=('libming' 'ffmpeg' 'qt5-svg' 'qt5-multimedia' 'qt5-tools')
-source=("${pkgname}.zip::https://github.com/pencil2d/pencil/archive/${_commit}.zip"
-        'pencil2d.desktop')
-md5sums=('e444e8501f66bf62b79cede47f89fd87'
-         '98008076937080db82a939d8129ed2d0')
+depends=('ffmpeg' 'qt5-svg' 'qt5-multimedia' 'qt5-tools')
+source=("${pkgname}.zip::https://github.com/pencil2d/pencil/archive/${_commit}.zip")
+md5sums=('6cadf1803114cdf04dbf53d8b459ee9e')
 
 prepare() {
     cd "${srcdir}/pencil-${_commit}"
     if [ ! -e /usr/bin/qmake ] && [ -e /usr/lib/qt5/bin/qmake ]; then
         export PATH=$PATH:/usr/lib/qt5/bin
     fi
-    qmake
+    qmake CONFIG+=release CONFIG+=GIT CONFIG+=PENCIL2D_RELEASE
 }
 
 build() {
@@ -27,8 +25,5 @@ build() {
 
 package() {
     cd "${srcdir}/pencil-${_commit}"
-    make DESTDIR="${pkgdir}" install
-    install -Dm755 "${srcdir}/pencil-${_commit}/app/Pencil2D" "${pkgdir}/usr/bin/pencil2d"
-    install -Dm644 "${srcdir}/pencil-${_commit}/icons/pencil.png" "${pkgdir}/usr/share/icons/hicolor/32x32/apps/pencil2d.png"
-    install -Dm644 "${srcdir}/pencil2d.desktop" "${pkgdir}/usr/share/applications/pencil2d.desktop"
+    make INSTALL_ROOT="${pkgdir}/usr" install
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# pencil2d
-Animation software for both bitmap and vector graphics
+# Pencil2D KaOS Community Package
+This repository contains the community package release of Pencil2D for KaOS. Pencil2D is an open source animation program. More information on Pencil2D can be found on it's official website at [https://www.pencil2d.org](https://www.pencil2d.org).

--- a/pencil2d.desktop
+++ b/pencil2d.desktop
@@ -1,6 +1,0 @@
-[Desktop Entry]
-Type=Application
-Name=Pencil
-Exec=pencil2d %F
-Icon=pencil2d
-Categories=Graphics;2DGraphics;


### PR DESCRIPTION
This updates Pencil2D to the latest version (v0.6.6) and applies some of the same settings uses for the official builds. I have tested it and it seems to install and run fine, and it passes pckcp, but I don't have any other experience with this type of packaging so if there is something wrong with it let me know.